### PR TITLE
Do not include helm ConfigMaps by default

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,13 @@ for namespace in $NAMESPACES; do
 
   for type in $RESOURCETYPES; do
     echo "[${namespace}] Exporting resources: ${type}" > /dev/stderr
-    /kubectl --namespace="${namespace}" get --export -o=json $type | jq --sort-keys \
+
+    label_selector=""
+    if [[ $type == 'configmap' && -z "${INCLUDE_TILLER_CONFIGMAPS:-}" ]]; then
+      label_selector="-l OWNER!=TILLER"
+    fi
+
+    /kubectl --namespace="${namespace}" get --export -o=json $type $label_selector | jq --sort-keys \
         'select(.type!="kubernetes.io/service-account-token") |
         del(
             .items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",


### PR DESCRIPTION
they probably contain (gziped, base64 encoded) secrets

It's kind of a shame not to capture them in a backup but I can't have (even very obfuscated) secrets in my backup repo, plus with the versioning there may be quite a few. 

While in principle secret values could be included as a `Secret` out of band (as with the install instructions of kube-backup) and not need to be part of values, this loses the one and done nature of `helm install`, so most (all?) official charts do not follow this pattern and instead do last mile injection via a `values.yaml` that is saved in whole as part of the `ConfigMap`s :(

![screen shot 2017-03-08 at 3 50 07 pm](https://cloud.githubusercontent.com/assets/43136/23723388/f8820de2-0416-11e7-93af-268af15fe18a.png)

With more support of e.g. https://github.com/skuid/helm-value-store this could change but for now its probably best not to back them up by default

(Warning: I am opening this PR before fully testing, but its pretty straightforward so I thought I'd get it on your plate first and test now) 