### PR TITLE
Add RBAC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ kubectl create secret generic kube-backup-ssh -n kube-system --from-file=id_rsa 
 Optional:
   * Modify the snapshot frequency in `spec.schedule` using the [cron format](https://en.wikipedia.org/wiki/Cron).
   * Modify the number of successful and failed finished jobs to retain in `spec.successfulJobsHistoryLimit` and `spec.failedJobsHistoryLimit`.
+  * If using RBAC (1.6+), use the ClusterRole and ClusterRoleBindings in rbac.yaml.
 
 Result
 ------

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -1,3 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-backup
+  namespace: kube-system
+
+---
+
 apiVersion: batch/v2alpha1
 kind: CronJob
 metadata:
@@ -35,6 +43,7 @@ spec:
               name: sshkey
           dnsPolicy: ClusterFirst
           terminationGracePeriodSeconds: 30
+          serviceAccountName: kube-backup
           volumes:
           - name: sshkey
             secret:

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -1,0 +1,37 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-backup-reader
+rules:
+- apiGroups: ["*"]
+  resources: [
+    "configmaps",
+    "cronjobs",
+    "deployments",
+    "daemonsets",
+    "ingresses",
+    "namespaces",
+    "networkpolicies",
+    "replicationcontrollers",
+    "services",
+    "statefulsets",
+    "storageclasses",
+    "thirdpartyresources"
+  ]
+  verbs: ["get", "list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-backup
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: kube-backup
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kube-backup-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This patch provides a ServiceAccount, ClusterRole, and ClusterRole bindings with enough permissions for the backup.