### PR TITLE
Escape git name and email

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,8 @@ if [[ ! -f /backup/.ssh/id_rsa ]] ; then
     git config --global credential.helper '!aws codecommit credential-helper $@'
     git config --global credential.UseHttpPath true
 fi
-git config --global user.name $GIT_USERNAME
-git config --global user.email $GIT_EMAIL
+git config --global user.name "$GIT_USERNAME"
+git config --global user.email "$GIT_EMAIL"
 
 test -d /backup/git/ || git clone --depth 1 $GIT_REPO /backup/git --branch $GIT_BRANCH || git clone $GIT_REPO /backup/git
 cd /backup/git/


### PR DESCRIPTION
Thanks for this awesome projects that helps us to make a better Kubernetes infrastructure! With this, we can be almost certain that we can redeploy if necessary.

I did find a little bug though: when using a Git name containing a space, this fails with the `git config` command.

This PR fixes that by escaping the environment variables passed to `git config`.