### PR TITLE
Follow up on #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Use the deployment example ([ssh](cronjob-ssh.yaml) or [AWS CodeCommit](cronjob-
 
 Define the following environment parameters:
   * `GIT_REPO` - GIT repo url. **Required**
+  * `GIT_PREFIX_PATH` - Path to the subdirectory in your repository. Default: `.`
   * `NAMESPACES` - List of namespaces to export. Default: all
   * `GLOBALRESOURCES` - List of global resource types to export. Default: `namespace`
   * `RESOURCETYPES` - List of resource types to export. Default: `ingress deployment configmap svc rc ds thirdpartyresource networkpolicy statefulset storageclass cronjob`. Notice that `Secret` objects are intentionally not exported by default.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ GLOBALRESOURCES="${GLOBALRESOURCES:-"namespace storageclasses"}"
 # Initialize git repo
 [ -z "$GIT_REPO" ] && echo "Need to define GIT_REPO environment variable" && exit 1
 GIT_REPO_PATH="${GIT_REPO_PATH:-"/backup/git"}"
-GIT_PREFIX_PATH="${GIT_PREFIX_PATH:-""}"
+GIT_PREFIX_PATH="${GIT_PREFIX_PATH:-"."}"
 GIT_USERNAME="${GIT_USERNAME:-"kube-backup"}"
 GIT_EMAIL="${GIT_EMAIL:-"kube-backup@example.com"}"
 GIT_BRANCH="${GIT_BRANCH:-"master"}"
@@ -25,7 +25,7 @@ git config --global user.email "$GIT_EMAIL"
 test -d "$GIT_REPO_PATH" || git clone --depth 1 "$GIT_REPO" "$GIT_REPO_PATH" --branch "$GIT_BRANCH" || git clone "$GIT_REPO" "$GIT_REPO_PATH"
 cd "$GIT_REPO_PATH"
 git checkout "${GIT_BRANCH}" || git checkout -b "${GIT_BRANCH}"
-git rm -r . || true
+git rm -r "${GIT_PREFIX_PATH}" || true
 
 # Start kubernetes state export
 for resource in $GLOBALRESOURCES; do
@@ -54,7 +54,7 @@ for namespace in $NAMESPACES; do
       label_selector="-l OWNER!=TILLER"
     fi
 
-    /kubectl --namespace="${namespace}" get --export -o=json "$type" "$label_selector" | jq --sort-keys \
+    /kubectl --namespace="${namespace}" get --export -o=json "$type" $label_selector | jq --sort-keys \
         'select(.type!="kubernetes.io/service-account-token") |
         del(
             .items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",


### PR DESCRIPTION
- clean repository only for provided prefix path
- fix for label selection, which cannot be inside double quota
- Add new variable to readme

This commit also sets the default value of GIT_PREFIX_PATH to "."
which stands for the root directory under git repository.