### PR TITLE
Git crypt fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To enable encryption feature:
     kind: Secret
     metadata:
       name: kube-backup-gpg
-      namespace: backups
+      namespace: kube-system
     data:
       gpg-private.key: <base64_encoded_key>
       symmetric.key: <base64_encoded_key>

--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ To enable encryption feature:
         - name: RESOURCETYPES
           value: "ingress deployment configmap secret svc rc ds thirdpartyresource networkpolicy statefulset storageclass cronjob"
     ```
+  * If using RBAC (1.6+), add `secrets` to `resources`
+    ```
+    rules:
+    - apiGroups: ["*"]
+      resources: [
+        "configmaps",
+        "secrets",
+    ```
 
   * (Optional): `$GITCRYPT_PRIVATE_KEY` and `$GITCRYPT_SYMMETRIC_KEY` variables are the combination of path where `Secret` volume is mounted and the name of item key from that object. If you change any value of them from the above example you may need to set this variables accordingly.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,8 @@ if [ "$GITCRYPT_ENABLE" = "true" ]; then
     exit 1
   fi
 fi
-git rm -r "${GIT_PREFIX_PATH}" || true
+cd "$GIT_REPO_PATH/$GIT_PREFIX_PATH"
+git rm -r **/*.yaml || true
 
 # Start kubernetes state export
 for resource in $GLOBALRESOURCES; do


### PR DESCRIPTION
I successfully set up `git-crypt` to encrypt the secrets in our backups, but I had to make a couple of changes compared to what is currently in the repo.

1/ The `git rm -r "${GIT_PREFIX_PATH}" || true` command deletes the `.gitattributes` that we got to create to set up `git-crypt` (https://github.com/pieterlange/kube-backup#prerequisites). As a result, the secrets are pushed without encryption. I came up with a solution that only git-removes *.yaml files.

2/ The cluster role `kube-backup-reader` needs access to the secrets (added in the README).

3/ The `kube-backup-gpg` Secret should be created in the `kube-system` namespace, just like the `kube-state-backup` CronJob.