### PR TITLE
fix error when runing 2+ times

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Your repository has to be already initialized with git-crypt. Minimal configurat
 cd repo
 git-crypt init
 cat <<EOF > .gitattributes
-*.secret.yaml filter=git-crypt diff=git-crypt
+*.secrets.yaml filter=git-crypt diff=git-crypt
 .gitattributes !filter !diff
 EOF
 git-crypt add-gpg-user <USER_ID>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,6 +99,7 @@ done
 
 [ -z "$DRY_RUN" ] || exit
 
+cd "${KUBE_BACKUP}"
 git add .
 
 if ! git diff-index --quiet HEAD --; then


### PR DESCRIPTION
Hi,

i was getting a reproducible error, when backup up to a subdir:
```
[monitoring] Exporting resources: pvc
/backup/git/prod2
fatal: Unable to read current working directory: No such file or directory
```
not really sure why this would be an issue because we are in the correct directory though.

This seemed like a quick/dirty fix.