### PR TITLE
changed apiVersion to batch/v1beta1, which does support the CronJob kind

### DIFF
--- a/job-cleanup.yaml
+++ b/job-cleanup.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: kube-state-backup-cleaner


### PR DESCRIPTION
The v2alpha1 version has an error for the CronJob type: "Error: validation failed: unable to recognize "": no matches for kind "CronJob" in version "v1" ". Replacing it with v1beta1 solves this issue.