### PR TITLE
Fixup variable quoting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,7 @@ for namespace in $NAMESPACES; do
         fi
 
         kubectl --namespace="${namespace}" get "$type" $label_selector -o custom-columns=SPACE:.metadata.namespace,KIND:..kind,NAME:.metadata.name --no-headers | while read -r a b name; do
-            [ -z $name ] && continue
+            [ -z "$name" ] && continue
 
         # Service account tokens cannot be exported
         if [[ "$type" == 'secret' && $(kubectl get -n "${namespace}" -o jsonpath="{.type}" secret "$name") == "kubernetes.io/service-account-token" ]]; then


### PR DESCRIPTION
If this variable isn't quoted, this check will die with a syntax error when $name is empty or contains more than one word