### PR TITLE
better clusterIP filtering logic, add default services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,6 @@ RUN echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c - || exit 10
 ENV PATH="/:${PATH}"
 
 COPY entrypoint.sh /
+COPY reflow.py /bin/
 USER backup
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Define the following environment parameters:
   * `GIT_REPO` - GIT repo url. **Required**
   * `GIT_PREFIX_PATH` - Path to the subdirectory in your repository. Default: `.`
   * `NAMESPACES` - List of namespaces to export. Default: all
-  * `GLOBALRESOURCES` - List of global resource types to export. Default: `namespace`
-  * `RESOURCETYPES` - List of resource types to export. Default: `ingress deployment configmap svc rc ds networkpolicy statefulset storageclass cronjob`. Notice that `Secret` objects are intentionally not exported by default (see [git-crypt section](#git-crypt) for details).
+  * `DEFAULT_GLOBALRESOURCES` - Base list of global resource types to export. Default: `namespace storageclass clusterrole clusterrolebinding customresourcedefinition`
+  * `EXTRA_GLOBALRESOURCES` - List of additional global resource types to export, should you simply want to append to the default list rather than replacing it entirely. Optional. Default: empty.
+  * `DEFAULT_RESOURCETYPES` - Base list of resource types to export. Default: `ingress deployment configmap svc rc ds networkpolicy statefulset storageclass cronjob`. Notice that `Secret` objects are intentionally not exported by default (see [git-crypt section](#git-crypt) for details).
+  * `EXTRA_RESOURCETYPES` - List of additional resource types to export, should you simply want to append to the default list rather than replacing it entirely. Optional. Default: empty.
   * `GIT_USERNAME` - Display name of git user. Default: `kube-backup`
   * `GIT_EMAIL` - Email address of git user. Default: `kube-backup@example.com`
   * `GIT_BRANCH` - Use a specific git branch . Default: `master`

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p /tmp/backup
+DRY_RUN=true GIT_REPO_PATH=/tmp/backup ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,10 @@ if [ -z "$NAMESPACES" ]; then
     NAMESPACES=$(kubectl get ns -o jsonpath={.items[*].metadata.name})
 fi
 
-RESOURCETYPES="${RESOURCETYPES:-"ingress deployment configmap svc rc ds networkpolicy statefulset cronjob pvc backendconfig serviceaccount"}"
-GLOBALRESOURCES="${GLOBALRESOURCES:-"namespace storageclass clusterrole clusterrolebinding customresourcedefinition"}"
+DEFAULT_RESOURCETYPES="${DEFAULT_RESOURCETYPES:-"ingress deployment configmap svc rc ds networkpolicy statefulset cronjob pvc serviceaccount"}"
+RESOURCETYPES="${DEFAULT_RESOURCETYPES} ${EXTRA_RESOURCETYPES}"
+DEFAULT_GLOBALRESOURCES="${DEFAULT_GLOBALRESOURCES:-"namespace storageclass clusterrole clusterrolebinding customresourcedefinition"}"
+GLOBALRESOURCES="${DEFAULT_GLOBALRESOURCES} ${EXTRA_GLOBALRESOURCES}"
 
 # Initialize git repo
 [ -z "$DRY_RUN" ] && [ -z "$GIT_REPO" ] && echo "Need to define GIT_REPO environment variable" && exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ for resource in $GLOBALRESOURCES; do
           .items[].metadata.resourceVersion,
           .items[].metadata.creationTimestamp,
           .items[].metadata.generation
-      )' | python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
+      )' | /bin/reflow.py >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
 done
 
 for namespace in $NAMESPACES; do

--- a/reflow.py
+++ b/reflow.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import sys
+import yaml
+import json
+
+data = json.load(sys.stdin)
+
+# we don't want to preserve 'clusterIP: <ip address>' because in
+# a restore-from-scratch situation the value will be bogus, but
+# if the value is "None", that indicates a headless service and
+# we _do_ want to preserve that.
+if 'spec' in data:
+    if 'clusterIP' in data['spec']:
+        if data['spec']['clusterIP'] != "None":
+            del(data['spec']['clusterIP'])
+
+yaml.safe_dump(data, sys.stdout, explicit_start=True, default_flow_style=False)


### PR DESCRIPTION
- pull the inline python one-liner out into a separate script so
  that we can:

- apply better logic around filtering out service.spec.clusterIP:
  if the value is "None" that's a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services)
  and _not_ preserving the value will result in the creation of
  a NON-headless service, which is likely to be extremely wrong.

- set `explicit_start=True` in the call to pyyaml.safe_dump() so
  that backup files can be safely concatenated together

- add [serviceaccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to the list of default resources

- update the README with the current defaults

- add `EXTRA_` env vars for the resource lists so that they can be appended to as well as overwritten