### PR TITLE
Always clone a fresh copy of the repo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,8 @@ fi
 [ -z "$DRY_RUN" ] && git config --global user.name "$GIT_USERNAME"
 [ -z "$DRY_RUN" ] && git config --global user.email "$GIT_EMAIL"
 
-[ -z "$DRY_RUN" ] && (test -d "$GIT_REPO_PATH" || git clone --depth 1 "$GIT_REPO" "$GIT_REPO_PATH" --branch "$GIT_BRANCH" || git clone "$GIT_REPO" "$GIT_REPO_PATH")
+[ -z "$DRY_RUN" ] && (test ! -e "$GIT_REPO_PATH" || rm -rf ${GIT_REPO_PATH})
+[ -z "$DRY_RUN" ] && (git clone --depth 1 "$GIT_REPO" "$GIT_REPO_PATH" --branch "$GIT_BRANCH" || git clone "$GIT_REPO" "$GIT_REPO_PATH")
 cd "$GIT_REPO_PATH"
 [ -z "$DRY_RUN" ] && (git checkout "${GIT_BRANCH}" || git checkout -b "${GIT_BRANCH}")
 


### PR DESCRIPTION
The restart policy of OnFailure causes the same pod to be restarted if there's a problem.
This is an issue if that pod already has the changes checked in, as the rest of the script will not find changes (or attempt to commit or push them) resulting in the second attempt always passing (masking the problem).
This change ensure's there's a clean repo on each run, so successive restarts will correctly try (and potentially fail) again.