### PR TITLE
add workaround to exlude cluster-autoscaler-status.configmap.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN apk update && \
     py2-pip \
     libstdc++ \
     gpgme \
-    git-crypt \
-    && \
-  rm -rf /var/cache/apk/*
+    git-crypt
+
+RUN rm -rf /var/cache/apk/*
 
 RUN pip install ijson awscli
 RUN adduser -h /backup -D backup

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,6 +81,11 @@ for namespace in $NAMESPACES; do
             continue
         fi
 
+        # bil: workaround to exclude cluster-autoscaler-status.configmap.yml as it produces noise everytime
+        if [[ "$type" == 'configmap' && "${namespace}" == 'kube-system' && "$name" == 'cluster-autoscaler-status' ]]; then
+            continue
+        fi
+
         kubectl --namespace="${namespace}" get -o=json "$type" "$name" | jq --sort-keys \
         'del(
             .metadata.annotations."control-plane.alpha.kubernetes.io/leader",


### PR DESCRIPTION
hi @pieterlange , I'd like to contribute a workaround that I face when using kube-backup at work.
the problem is `cluster-autoscaler-status.configmap.yml` always changing and thus always be committed to the backup repo.
The problem with that it makes tons of commits and hard to see when real changes happen. thus in this commit I'd like to exclude `cluster-autoscaler-status.configmap.yml` so it wont be pushed. thank you