### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.14
 
 RUN apk update && \
   apk add --update \
@@ -9,9 +9,9 @@ RUN apk update && \
     curl \
     ca-certificates \
     jq \
-    python \
-    py-yaml \
-    py2-pip \
+    python3 \
+    py3-yaml \
+    py3-pip \
     libstdc++ \
     gpgme \
     git-crypt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,13 @@ RUN apk update && \
 RUN pip install ijson awscli
 RUN adduser -h /backup -D backup
 
-ENV KUBECTL_VERSION 1.17.0
-ENV KUBECTL_SHA256 6e0aaaffe5507a44ec6b1b8a0fb585285813b78cc045f8804e70a6aac9d1cb4c
-ENV KUBECTL_URI https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+ARG KUBECTL_VERSION="1.17.0"
+ARG KUBECTL_SHA256="6e0aaaffe5507a44ec6b1b8a0fb585285813b78cc045f8804e70a6aac9d1cb4c"
 
-RUN curl -SL ${KUBECTL_URI} -o kubectl && chmod +x kubectl
-
-RUN echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c - || exit 10
-ENV PATH="/:${PATH}"
+RUN curl -SL \
+  "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && \
+  chmod +x /usr/local/bin/kubectl
+RUN echo "${KUBECTL_SHA256}  /usr/local/bin/kubectl" | sha256sum -c - || exit 10
 
 COPY entrypoint.sh /
 USER backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN apk update && \
 RUN pip install ijson awscli
 RUN adduser -h /backup -D backup
 
-ARG KUBECTL_VERSION="1.17.0"
-ARG KUBECTL_SHA256="6e0aaaffe5507a44ec6b1b8a0fb585285813b78cc045f8804e70a6aac9d1cb4c"
+ARG KUBECTL_VERSION="1.21.5"
+ARG KUBECTL_SHA256="060ede75550c63bdc84e14fcc4c8ab3017f7ffc032fc4cac3bf20d274fab1be4"
 
 RUN curl -SL \
-  "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && \
+  "https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && \
   chmod +x /usr/local/bin/kubectl
 RUN echo "${KUBECTL_SHA256}  /usr/local/bin/kubectl" | sha256sum -c - || exit 10
 

--- a/cronjob-ssh.yaml
+++ b/cronjob-ssh.yaml
@@ -6,7 +6,7 @@ metadata:
 
 ---
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: kube-state-backup

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -n "$1" ]; then
 fi
 
 if [ -z "$NAMESPACES" ]; then
-    NAMESPACES=$(kubectl get ns -o jsonpath={.items[*].metadata.name})
+    NAMESPACES=$(kubectl get ns -o jsonpath='{.items[*].metadata.name}')
 fi
 
 RESOURCETYPES="${RESOURCETYPES:-"ingress deployment configmap svc rc ds networkpolicy statefulset cronjob pvc"}"
@@ -77,7 +77,8 @@ for namespace in $NAMESPACES; do
             label_selector="-l OWNER!=TILLER"
         fi
 
-        kubectl --namespace="${namespace}" get "$type" $label_selector -o custom-columns=SPACE:.metadata.namespace,KIND:..kind,NAME:.metadata.name --no-headers | while read -r a b name; do
+        # shellcheck disable=SC2086
+        kubectl --namespace="${namespace}" get "$type" $label_selector -o custom-columns=SPACE:.metadata.namespace,KIND:..kind,NAME:.metadata.name --no-headers | while read -r _ _ name; do
             [ -z "$name" ] && continue
 
             # Service account tokens cannot be exported

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ for resource in $GLOBALRESOURCES; do
             .items[].metadata.resourceVersion,
             .items[].metadata.creationTimestamp,
             .items[].metadata.generation
-        )' | python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
+        )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
 done
 
 for namespace in $NAMESPACES; do
@@ -97,7 +97,7 @@ for namespace in $NAMESPACES; do
                 .metadata.uid,
                 .spec.clusterIP,
                 .status
-            )' | python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}/${name}.${type}.yaml"
+            )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}/${name}.${type}.yaml"
         done
     done
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ fi
 
 # Start kubernetes state export
 for resource in $GLOBALRESOURCES; do
-    [ -d "$GIT_REPO_PATH/$GIT_PREFIX_PATH" ] || mkdir -p "$GIT_REPO_PATH/$GIT_PREFIX_PATH"
+    mkdir -p "$GIT_REPO_PATH/$GIT_PREFIX_PATH"
     echo "Exporting resource: ${resource}" >&2
     kubectl get -o=json "$resource" | jq --sort-keys \
         'del(
@@ -63,7 +63,7 @@ for resource in $GLOBALRESOURCES; do
 done
 
 for namespace in $NAMESPACES; do
-    [ -d "$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}" ] || mkdir -p "$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}"
+    mkdir -p "$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}"
 
     for type in $RESOURCETYPES; do
         echo "[${namespace}] Exporting resources: ${type}" >&2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,8 @@ for resource in $GLOBALRESOURCES; do
             .items[].metadata.selfLink,
             .items[].metadata.resourceVersion,
             .items[].metadata.creationTimestamp,
-            .items[].metadata.generation
+            .items[].metadata.generation,
+            .items[].metadata.managedFields
         )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
 done
 
@@ -95,6 +96,7 @@ for namespace in $NAMESPACES; do
                 .metadata.resourceVersion,
                 .metadata.selfLink,
                 .metadata.uid,
+                .metadata.managedFields,
                 .spec.clusterIP,
                 .status
             )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}/${name}.${type}.yaml"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,7 +64,8 @@ for resource in $GLOBALRESOURCES; do
             .items[].metadata.creationTimestamp,
             .items[].metadata.generation,
             .items[].metadata.managedFields,
-            .items[].status
+            .items[].status,
+            .metadata
         )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
 done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,14 +56,14 @@ for resource in $GLOBALRESOURCES; do
     echo "Exporting resource: ${resource}" >&2
     kubectl get -o=json "$resource" | jq --sort-keys \
         'del(
-          .items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",
-          .items[].metadata.annotations."control-plane.alpha.kubernetes.io/leader",
-          .items[].metadata.uid,
-          .items[].metadata.selfLink,
-          .items[].metadata.resourceVersion,
-          .items[].metadata.creationTimestamp,
-          .items[].metadata.generation
-      )' | python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
+            .items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",
+            .items[].metadata.annotations."control-plane.alpha.kubernetes.io/leader",
+            .items[].metadata.uid,
+            .items[].metadata.selfLink,
+            .items[].metadata.resourceVersion,
+            .items[].metadata.creationTimestamp,
+            .items[].metadata.generation
+        )' | python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
 done
 
 for namespace in $NAMESPACES; do
@@ -80,23 +80,23 @@ for namespace in $NAMESPACES; do
         kubectl --namespace="${namespace}" get "$type" $label_selector -o custom-columns=SPACE:.metadata.namespace,KIND:..kind,NAME:.metadata.name --no-headers | while read -r a b name; do
             [ -z "$name" ] && continue
 
-        # Service account tokens cannot be exported
-        if [ "$type" = 'secret' ] && [ "$(kubectl get -n "${namespace}" -o jsonpath="{.type}" secret "$name")" = "kubernetes.io/service-account-token" ]; then
-            continue
-        fi
+            # Service account tokens cannot be exported
+            if [ "$type" = 'secret' ] && [ "$(kubectl get -n "${namespace}" -o jsonpath="{.type}" secret "$name")" = "kubernetes.io/service-account-token" ]; then
+                continue
+            fi
 
-        kubectl --namespace="${namespace}" get -o=json "$type" "$name" | jq --sort-keys \
-        'del(
-            .metadata.annotations."control-plane.alpha.kubernetes.io/leader",
-            .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",
-            .metadata.creationTimestamp,
-            .metadata.generation,
-            .metadata.resourceVersion,
-            .metadata.selfLink,
-            .metadata.uid,
-            .spec.clusterIP,
-            .status
-        )' | python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}/${name}.${type}.yaml"
+            kubectl --namespace="${namespace}" get -o=json "$type" "$name" | jq --sort-keys \
+            'del(
+                .metadata.annotations."control-plane.alpha.kubernetes.io/leader",
+                .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",
+                .metadata.creationTimestamp,
+                .metadata.generation,
+                .metadata.resourceVersion,
+                .metadata.selfLink,
+                .metadata.uid,
+                .spec.clusterIP,
+                .status
+            )' | python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}/${name}.${type}.yaml"
         done
     done
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,8 @@ for resource in $GLOBALRESOURCES; do
             .items[].metadata.resourceVersion,
             .items[].metadata.creationTimestamp,
             .items[].metadata.generation,
-            .items[].metadata.managedFields
+            .items[].metadata.managedFields,
+            .items[].status
         )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
 done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,6 +88,11 @@ for namespace in $NAMESPACES; do
                 continue
             fi
 
+            # Skip kube-root-ca.crt config maps
+            if [ "$type" = 'configmap' ] && [ "$name" = 'kube-root-ca.crt' ]; then
+                continue
+            fi
+
             kubectl --namespace="${namespace}" get -o=json "$type" "$name" | jq --sort-keys \
             'del(
                 .metadata.annotations."control-plane.alpha.kubernetes.io/leader",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,7 @@ for resource in $GLOBALRESOURCES; do
             .items[].metadata.creationTimestamp,
             .items[].metadata.generation,
             .items[].metadata.managedFields,
+            .items[].metadata.ownerReferences,
             .items[].status,
             .metadata
         )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${resource}.yaml"
@@ -104,6 +105,7 @@ for namespace in $NAMESPACES; do
                 .metadata.selfLink,
                 .metadata.uid,
                 .metadata.managedFields,
+                .metadata.ownerReferences,
                 .spec.clusterIP,
                 .status
             )' | python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' >"$GIT_REPO_PATH/$GIT_PREFIX_PATH/${namespace}/${name}.${type}.yaml"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ -n "$1" ]; then
+    exec "$@"
+    exit
+fi
+
 if [ -z "$NAMESPACES" ]; then
     NAMESPACES=$(kubectl get ns -o jsonpath={.items[*].metadata.name})
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,6 @@ fi
 
 # Start kubernetes state export
 for resource in $GLOBALRESOURCES; do
-    mkdir -p "$GIT_REPO_PATH/$GIT_PREFIX_PATH"
     echo "Exporting resource: ${resource}" >&2
     kubectl get -o=json "$resource" | jq --sort-keys \
         'del(


### PR DESCRIPTION
Requires #72
* this branch needs to be rebased onto master once `cleanup` is merged

Update dependencies:

* Alpine 3.14
* Python 3
* kubectl 1.21.5 (supports 1.19 to 1.22)

:warning: AWS support has not been checked (I have removed the support in [my fork](https://gitlab.ewd.app/Exagone313/kube-backup))

Update for newer Kubernetes versions:

* Do not backup managedFields
* Do not save status of global resources
* Update apiVersion
* Skip kube-root-ca.crt config maps
* Remove global resource List metadata
* Do not backup ownerReferences

NB: I'm always happy to edit history if requested.